### PR TITLE
fix: background component throwing error when icons not available

### DIFF
--- a/src/app/components/Background.tsx
+++ b/src/app/components/Background.tsx
@@ -17,7 +17,7 @@ const Background = ({
       <svg width="100%" height="100%">
         <defs>
           <linearGradient id={id} x1="50%" y1="0%" x2="75%" y2="100%">
-            {colorStops.map((color, i) => (
+            {colorStops?.map((color, i) => (
               <stop key={i} offset={`${offsets[i]}%`} stopColor={color} />
             ))}
           </linearGradient>

--- a/src/app/components/Header/Temperature.tsx
+++ b/src/app/components/Header/Temperature.tsx
@@ -82,8 +82,8 @@ const Temperature = () => {
               icon={'min'}
               x={0}
               y={0}
-              width={'1rem'}
-              height={'1rem'}
+              width={16}
+              height={16}
               viewBox="0 0 24 24"
             />
             <div className="text-sm font-medium md:text-xl">
@@ -97,8 +97,8 @@ const Temperature = () => {
               icon={'max'}
               x={0}
               y={0}
-              width={'1rem'}
-              height={'1rem'}
+              width={16}
+              height={16}
               viewBox="0 0 24 24"
             />
             <div className="text-sm font-medium md:text-xl">


### PR DESCRIPTION
Add fallback value to the timestamp icon when undefined. This was causing the background to break.